### PR TITLE
Hotfix PR 

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\lucam\.android\avd\Pixel_2_API_33.avd" />
+            <type value="SERIAL_NUMBER" />
+            <value value="adb-R3CNC0D3P9J-jhMnrz._adb-tls-connect._tcp" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-03-16T18:49:43.629110200Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-03-30T16:09:05.507373600Z" />
   </component>
 </project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application

--- a/app/src/main/java/ch/epfl/culturequest/ProfileCreatorActivity.java
+++ b/app/src/main/java/ch/epfl/culturequest/ProfileCreatorActivity.java
@@ -50,11 +50,9 @@ public class ProfileCreatorActivity extends AppCompatActivity {
                         if (isGranted) openGallery();
                     });
 
-    private final PermissionRequest permissionRequest =
-            new PermissionRequest(Manifest.permission.READ_EXTERNAL_STORAGE);
+    private final PermissionRequest permissionRequest = new PermissionRequest(ProfileUtils.GALLERY_PERMISSION);
     private ImageView profileView;
     private Drawable initialDrawable;
-    private Database db = new Database();
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/ch/epfl/culturequest/utils/ProfileUtils.java
+++ b/app/src/main/java/ch/epfl/culturequest/utils/ProfileUtils.java
@@ -3,6 +3,7 @@ package ch.epfl.culturequest.utils;
 import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.provider.MediaStore;
 import android.view.View;
 
@@ -25,7 +26,11 @@ public class ProfileUtils {
     public static String INCORRECT_USERNAME_FORMAT = "Incorrect Username Format";
     public static String USERNAME_REGEX = "^[a-zA-Z0-9_-]+$";
 
-    public static final String GALLERY_PERMISSION = Manifest.permission.READ_EXTERNAL_STORAGE;
+    public static final String GALLERY_PERMISSION =
+            //Version code R is android 11.
+            Build.VERSION.SDK_INT > Build.VERSION_CODES.R ?
+                    Manifest.permission.READ_MEDIA_IMAGES :
+                    Manifest.permission.READ_EXTERNAL_STORAGE;
 
 
     /**

--- a/app/src/main/res/layout/fragment_leaderboard.xml
+++ b/app/src/main/res/layout/fragment_leaderboard.xml
@@ -101,7 +101,9 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
-        android:layout_height="410dp"
-        app:layout_constraintTop_toBottomOf="@+id/horizontal_bar" />
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@+id/horizontal_bar"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
fixing issue related to permissions for devices over android 11:
Modified the permission that is required to select a profile picture.

Basically when running the app on my phone (android 11) with the permission read_media_image, i couldn't select a profile pic, but running the app on other ppls phones (android 13), with the permission read_external_storage, we couldn't select a profile pic
As such i put the threshold of the permission to android 11.

Modified leaderboard layout to be the size of the screen