### PR TITLE
feat: improve the user search algorithm (#80)

### DIFF
--- a/app/src/androidTest/java/ch/epfl/culturequest/ui/SearchUserActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/ui/SearchUserActivityTest.java
@@ -124,12 +124,7 @@ public class SearchUserActivityTest {
         assertEquals(expectedIntent.getComponent(), secondActivity.getIntent().getComponent());
     }
 
-    @Test
-    public void wrongUsernameFormatDoesntDisplayAnything(){
-        onView(withId(R.id.search_user)).perform(typeText("Username is wrong"));
-        onView(withId(R.id.list_view))
-                .check(matches(Matchers.not(hasMinimumChildCount(1))));
-    }
+
     @After
     public void teardown() {
         //Database.deleteProfile("testUid1");

--- a/app/src/main/java/ch/epfl/culturequest/ui/SearchUserActivity.java
+++ b/app/src/main/java/ch/epfl/culturequest/ui/SearchUserActivity.java
@@ -8,6 +8,7 @@ import android.view.Gravity;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.AutoCompleteTextView;
 import android.widget.EditText;
 import android.widget.ListView;
 
@@ -24,6 +25,7 @@ import ch.epfl.culturequest.social.Profile;
 import ch.epfl.culturequest.ui.profile.DisplayUserProfileActivity;
 import ch.epfl.culturequest.utils.AndroidUtils;
 import ch.epfl.culturequest.utils.ProfileUtils;
+import ch.epfl.culturequest.utils.AutoComplete;
 
 /**
  * This class represents the activity that is opened from the home fragment when we
@@ -32,6 +34,8 @@ import ch.epfl.culturequest.utils.ProfileUtils;
 public class SearchUserActivity extends AppCompatActivity {
     //the following watcher allows us to search for users dynamically without having to enter
     //the whole username to search for users
+
+    public static final int NUMBER_USERS_TO_DISPLAY = 5;
     TextWatcher watcher = new TextWatcher() {
         @Override
         public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
@@ -62,9 +66,6 @@ public class SearchUserActivity extends AppCompatActivity {
      * in a list view. When clicking on a profile in the list view, it opens the activity
      * DisplayUserProfileActivity.
      *
-     * In the future, to improve the search algorithm, we can implement the Levenshtein distance
-     * instead of startsWith(..).
-     *
      * @param query username to look for.
      */
     public void searchUserDynamically(String query) {
@@ -74,16 +75,12 @@ public class SearchUserActivity extends AppCompatActivity {
             Database.getAllProfiles().whenComplete((profiles, throwable) -> {
                 Map<String, Profile> usernameToProfileMap = profiles.stream()
                         .collect(Collectors.toMap(Profile::getUsername, profile -> profile));
-                List<String> matchingUsernames = usernameToProfileMap
-                        .keySet()
-                        .stream()
-                        .filter(username -> username.startsWith(query))
-                        .collect(Collectors.toList());
+
+                List<String> matchingUsernames = AutoComplete.topNMatches(query,usernameToProfileMap.keySet(),NUMBER_USERS_TO_DISPLAY);
+
                 ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, matchingUsernames);
                 listView.setAdapter(adapter);
-                listView.setOnItemClickListener((parent, ignored, position, ignored2) -> {
-                    searchBarOnClickListener(parent, position, usernameToProfileMap);
-                });
+                listView.setOnItemClickListener((parent, ignored, position, ignored2) -> searchBarOnClickListener(parent, position, usernameToProfileMap));
             });
         } else {
             ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, List.of());

--- a/app/src/main/java/ch/epfl/culturequest/utils/AutoComplete.java
+++ b/app/src/main/java/ch/epfl/culturequest/utils/AutoComplete.java
@@ -1,0 +1,94 @@
+package ch.epfl.culturequest.utils;
+
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+import java.util.AbstractMap.SimpleEntry;
+
+/**
+ * A class that provides methods to perform auto-completion on a dictionary.
+ */
+public class AutoComplete {
+    private static final int PENALTY = 1000;
+
+
+    /**
+     * Returns the top n matches for a given word in a dictionary using the Levenshtein distance.
+     * The complexity of this algorithm is O(a*b*m*log n), where:
+     *  -a is the length of the input word,
+     *  -b is the length of the longest word in the dictionary.
+     *  -m is the size of the dictionary,
+     *  -n is the number of top matches to return.
+     * @param word the word to match
+     * @param dictionary the dictionary to match against
+     * @param n the number of top matches to return
+     * @return the top 5 matches for the word in the dictionary
+     */
+    public static List<String> topNMatches(String word, Set<String> dictionary,int n) {
+        // Convert the input word to lowercase
+        String lowerWord = word.toLowerCase();
+
+        // Create a priority queue to store the top n matches along with their Levenshtein distance
+        PriorityQueue<SimpleEntry<String, Integer>> topMatches = new PriorityQueue<>(
+                Comparator.comparingInt(SimpleEntry<String, Integer>::getValue).reversed());
+
+
+        for (String entry : dictionary) {
+            String lowerEntry = entry.toLowerCase();
+            // Calculate the Levenshtein distance, with penalty if the entry doesn't start with the input word
+            int distance = levenshteinDistance(lowerEntry, lowerWord) + (lowerEntry.startsWith(lowerWord) ? 0 : PENALTY);
+
+            // Insert the entry and its distance into the priority queue
+            topMatches.offer(new SimpleEntry<>(entry, distance));
+            // Remove the entry with the highest distance if the priority queue size is greater than 5
+            if (topMatches.size() > n) {
+                topMatches.poll();
+            }
+        }
+
+        List<String> result = new ArrayList<>(topMatches.size());
+
+        // Add entries from the priority queue to the result list in reverse order of their distance
+        while (!topMatches.isEmpty()) {
+            result.add(Objects.requireNonNull(topMatches.poll()).getKey());
+        }
+        // Reverse the result list to have entries in ascending order of their distance
+        Collections.reverse(result);
+
+        return result;
+    }
+
+
+    /**
+     * Computes the Levenshtein distance between two strings.
+     * <a href="https://en.wikipedia.org/wiki/Levenshtein_distance">https://en.wikipedia.org/wiki/Levenshtein_distance</a>
+     * @param a first string
+     * @param b second string
+     * @return the Levenshtein distance between a and b
+     */
+    private static int levenshteinDistance(String a, String b) {
+        int[][] distance = new int[a.length() + 1][b.length() + 1];
+
+        // initialize the default values
+        for (int i = 0; i <= a.length(); i++)
+            distance[i][0] = i;
+        for (int j = 1; j <= b.length(); j++)
+            distance[0][j] = j;
+
+        for (int i = 1; i <= a.length(); i++)
+            for (int j = 1; j <= b.length(); j++)
+                // compute the distance
+                distance[i][j] = Math.min(Math.min(distance[i - 1][j] + 1, distance[i][j - 1] + 1),
+                        distance[i - 1][j - 1] + ((a.charAt(i - 1) == b.charAt(j - 1)) ? 0 : 1));
+
+        return distance[a.length()][b.length()];
+    }
+
+}

--- a/app/src/test/java/ch/epfl/culturequest/utils/AutoCompleteTest.java
+++ b/app/src/test/java/ch/epfl/culturequest/utils/AutoCompleteTest.java
@@ -1,0 +1,33 @@
+package ch.epfl.culturequest.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import io.reactivex.android.plugins.RxAndroidPlugins;
+import io.reactivex.schedulers.Schedulers;
+
+public class AutoCompleteTest {
+
+    @Rule
+    public InstantTaskExecutorRule instantExecutorRule = new InstantTaskExecutorRule();
+
+    @Before
+    public void setUp() {
+        RxAndroidPlugins.setInitMainThreadSchedulerHandler(schedulerCallable -> Schedulers.trampoline());
+    }
+
+    @Test
+    public void autoCompleteIsCorrect() {
+        Set<String> dictionary = Set.of("Albert","Alberto","Albertan","Al","alI","Luca","Ugo","Hugo","Thomas","John","Jack");
+        List<String> result = AutoComplete.topNMatches("Al", dictionary,5);
+        assertEquals(result, List.of("Al","alI","Albert","Alberto","Albertan"));
+    }
+}


### PR DESCRIPTION
This PR deals with displaying users' posts in their profiles, and other users profiles when consulting it. 
Initially, I decided to query only 4 posts at a time then add a onScrollListener but it was a bit messy when loading more posts, then i did some research and as this link says: it is better to have 1 large query than multiple smaller ones, even more so given that realistically, users won't have over 50 posts on the app. And the nice thing is that in the recycler view, it loads the image only when we scroll to it so the view is not overloaded
https://stackoverflow.com/questions/3910317/is-it-better-to-return-one-big-query-or-a-few-smaller-ones#:~:text=It%20is%20significantly%20faster%20to,the%20server%20more%20each%20time. 

So i decided to switch to 1 big query which returns all the posts and then displays them in a dummy XML while waiting for Albert to design the XML for the posts, which i will then adapt in this PR