### PR TITLE
Create notifications architecture for competitions and sightseeings

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -48,6 +48,7 @@
               <option name="preferredColumnWidths">
                 <map>
                   <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
                   <entry key="Tests" value="360" />
                 </map>
               </option>
@@ -109,6 +110,19 @@
           </value>
         </entry>
         <entry key="-1533604507">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-1529220418">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -16,6 +16,19 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="-2049512055">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="-1895405086">
           <value>
             <AndroidTestResultsTableState>
@@ -174,6 +187,19 @@
           </value>
         </entry>
         <entry key="-1278773526">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="-1168397290">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">
@@ -628,7 +654,46 @@
             </AndroidTestResultsTableState>
           </value>
         </entry>
+        <entry key="918798704">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1259935100">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="1260264952">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Pixel_2_API_33" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
+        <entry key="1270189532">
           <value>
             <AndroidTestResultsTableState>
               <option name="preferredColumnWidths">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
 </project>

--- a/app/src/androidTest/java/ch/epfl/culturequest/ArtDescriptionDisplayActivityOpenAiWarningTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/ArtDescriptionDisplayActivityOpenAiWarningTest.java
@@ -30,7 +30,7 @@ import ch.epfl.culturequest.utils.EspressoIdlingResource;
 
 public class ArtDescriptionDisplayActivityOpenAiWarningTest {
 
-    private Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    private final Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
 
     private String serializedMonaLisaDescription = "Pure Masterclass|Paris|France|Louvre|1519|Mona Lisa|Da Vinci|PAINTING|100|true";
 

--- a/app/src/androidTest/java/ch/epfl/culturequest/ArtDescriptionDisplayActivityOpenAiWarningTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/ArtDescriptionDisplayActivityOpenAiWarningTest.java
@@ -3,9 +3,7 @@ package ch.epfl.culturequest;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
-import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
-
 import static org.junit.Assert.assertThrows;
 
 import android.content.Context;
@@ -14,7 +12,6 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 
 import androidx.test.core.app.ApplicationProvider;
-import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.platform.app.InstrumentationRegistry;
@@ -26,7 +23,6 @@ import org.junit.Test;
 
 import ch.epfl.culturequest.storage.FireStorage;
 import ch.epfl.culturequest.storage.LocalStorage;
-import ch.epfl.culturequest.utils.EspressoIdlingResource;
 
 public class ArtDescriptionDisplayActivityOpenAiWarningTest {
 
@@ -55,7 +51,7 @@ public class ArtDescriptionDisplayActivityOpenAiWarningTest {
             localStorage.storeImageLocally(bitmap, true);
             Uri imageUri = localStorage.lastlyStoredImageUri;
             intent.putExtra("imageUri", imageUri.toString());
-        }catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -64,23 +60,17 @@ public class ArtDescriptionDisplayActivityOpenAiWarningTest {
 
     @Before
     public void setUp() {
-        // register IdlingResource
-        IdlingRegistry.getInstance().register(EspressoIdlingResource.countingIdlingResource);
         applicationContext = ApplicationProvider.getApplicationContext();
     }
 
     @After
     public void tearDown() {
-        // unregister IdlingResource
-        IdlingRegistry.getInstance().unregister(EspressoIdlingResource.countingIdlingResource);
         // clear the shared preferences
         applicationContext.getSharedPreferences("openAI_popup_pref", Context.MODE_PRIVATE).edit().clear().apply();
     }
 
     @Test
     public void popUpWindowCorrectlyAppearsOnScreen() {
-
-
         // Check that the TextView with the OpenAI message is displayed
         onView(withText(openAiWarningMessage)).check(matches(ViewMatchers.isDisplayed()));
 
@@ -96,7 +86,7 @@ public class ArtDescriptionDisplayActivityOpenAiWarningTest {
         });
 
         // check that the shared preferences have been updated
-        assert(applicationContext.getSharedPreferences("openAI_popup_pref", Context.MODE_PRIVATE).getBoolean("openAI_popup", true));
+        assert (applicationContext.getSharedPreferences("openAI_popup_pref", Context.MODE_PRIVATE).getBoolean("openAI_popup", true));
 
     }
 

--- a/app/src/androidTest/java/ch/epfl/culturequest/ProfileCreatorActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/ProfileCreatorActivityTest.java
@@ -12,7 +12,7 @@ import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentat
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static ch.epfl.culturequest.utils.ProfileUtils.DEFAULT_PROFILE_PATH;
+import static ch.epfl.culturequest.utils.ProfileUtils.DEFAULT_PROFILE_PIC_PATH;
 import static ch.epfl.culturequest.utils.ProfileUtils.INCORRECT_USERNAME_FORMAT;
 
 import android.Manifest;
@@ -127,8 +127,7 @@ public class ProfileCreatorActivityTest {
         onView(withId(R.id.create_profile)).perform(pressBack()).perform(click());
         Thread.sleep(8000);
         assertEquals("JohnDoe", profile.getUsername());
-        // assert  that the URL contains https://firebasestorage.googleapis.com and contains
-        assertEquals(DEFAULT_PROFILE_PATH, activity.getProfilePicUri());
+        assertEquals(DEFAULT_PROFILE_PIC_PATH, activity.getProfilePicUri());
     }
 
 

--- a/app/src/androidTest/java/ch/epfl/culturequest/SettingsActivityTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/SettingsActivityTest.java
@@ -11,7 +11,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static ch.epfl.culturequest.utils.ProfileUtils.DEFAULT_PROFILE_PATH;
+import static ch.epfl.culturequest.utils.ProfileUtils.DEFAULT_PROFILE_PIC_PATH;
 
 import android.Manifest;
 
@@ -63,7 +63,7 @@ public class SettingsActivityTest {
         // Manually signs in the user before the tests
         Authenticator.manualSignIn(email, password).join();
 
-        Profile.setActiveProfile(new Profile("userName", DEFAULT_PROFILE_PATH));
+        Profile.setActiveProfile(new Profile("userName", DEFAULT_PROFILE_PIC_PATH));
 
         ActivityScenario.launch(SettingsActivity.class).onActivity(a -> activity = a);
         Intents.init();

--- a/app/src/androidTest/java/ch/epfl/culturequest/social/notifications/CompetitionNotificationTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/social/notifications/CompetitionNotificationTest.java
@@ -1,0 +1,42 @@
+package ch.epfl.culturequest.social.notifications;
+
+import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import android.app.Notification;
+import android.content.Context;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+
+import ch.epfl.culturequest.R;
+import ch.epfl.culturequest.social.Profile;
+
+@RunWith(AndroidJUnit4.class)
+public class CompetitionNotificationTest {
+    private final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    private final Profile profile = new Profile("test", "test", "Competitor", "test", "test", "test", 0, new HashMap<>());
+
+    @Before
+    public void setup() {
+        NotificationInterface.createNotificationChannels(context);
+        Profile.setActiveProfile(profile);
+    }
+
+    @Test
+    public void testCompetitionNotification() {
+        Notification competitionNotification = new CompetitionNotification().get(context);
+        assertThat(competitionNotification.extras.get(Notification.EXTRA_TITLE).toString(), is(profile.getUsername() + ", you have a new competition!"));
+        assertThat(competitionNotification.extras.get(Notification.EXTRA_TEXT).toString(), is("Click here to see your new competition!"));
+        assertThat(competitionNotification.priority, is(Notification.PRIORITY_DEFAULT));
+        assertThat(competitionNotification.getSmallIcon().getResId(), is(R.drawable.logo_compact));
+        assertThat(competitionNotification.getChannelId(), is(CompetitionNotification.CHANNEL_ID));
+    }
+
+}

--- a/app/src/androidTest/java/ch/epfl/culturequest/social/notifications/FollowNotificationTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/social/notifications/FollowNotificationTest.java
@@ -6,34 +6,38 @@ import static org.hamcrest.Matchers.is;
 import android.app.Notification;
 import android.content.Context;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 
 import ch.epfl.culturequest.R;
 import ch.epfl.culturequest.social.Profile;
 
 
+@RunWith(AndroidJUnit4.class)
 public class FollowNotificationTest {
+    private final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    private final Profile profile = new Profile("test", "test", "Followee", "test", "test", "test", 0, new HashMap<>());
 
-    // Tests that the like notification is correctly created
+    @Before
+    public void setup() {
+        NotificationInterface.createNotificationChannels(context);
+        Profile.setActiveProfile(profile);
+    }
+
     @Test
-    public void testFollowNotification() {
-        Profile.setActiveProfile(new Profile("test", "Followee", "test", "test", "test", "test",0,new HashMap<>()));
-        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
-        android.app.Notification followNotification = new FollowNotification("Follower").get(context);
-        assertThat(followNotification.extras.get(Notification.EXTRA_TITLE).toString(), is("Followee, you have a new follower!"));
+    public void FollowNotificationIsCorrectlyCreated() {
+        Notification followNotification = new FollowNotification("Follower").get(context);
+        assertThat(followNotification.extras.get(Notification.EXTRA_TITLE).toString(), is(profile.getUsername() + ", you have a new follower!"));
         assertThat(followNotification.extras.get(Notification.EXTRA_TEXT).toString(), is("Follower is now following you!"));
         assertThat(followNotification.priority, is(Notification.PRIORITY_DEFAULT));
         assertThat(followNotification.getSmallIcon().getResId(), is(R.drawable.logo_compact));
-        assertThat(followNotification.getChannelId(), is(context.getString(R.string.followNotifChannelID)));
-
-        Profile.setActiveProfile(null);
+        assertThat(followNotification.getChannelId(), is(FollowNotification.CHANNEL_ID));
     }
 
 }

--- a/app/src/androidTest/java/ch/epfl/culturequest/social/notifications/LikeNotificationTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/social/notifications/LikeNotificationTest.java
@@ -6,9 +6,12 @@ import static org.hamcrest.Matchers.is;
 import android.app.Notification;
 import android.content.Context;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -18,22 +21,25 @@ import ch.epfl.culturequest.R;
 import ch.epfl.culturequest.social.Profile;
 
 
+@RunWith(AndroidJUnit4.class)
 public class LikeNotificationTest {
+    private final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    private final Profile profile = new Profile("test", "test", "Likee", "test", "test", "test",0,new HashMap<>());
 
-    // Tests that the like notification is correctly created
+    @Before
+    public void setup() {
+        NotificationInterface.createNotificationChannels(context);
+        Profile.setActiveProfile(profile);
+    }
+
     @Test
-    public void testLikeNotification() {
-        Profile.setActiveProfile(new Profile("test", "Likee", "test", "test", "test", "test",0,new HashMap<>()));
-        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
-        android.app.Notification likeNotification = new LikeNotification("Liker").get(context);
-        assertThat(likeNotification.extras.get(Notification.EXTRA_TITLE).toString(), is("Likee, you have a new like!"));
+    public void likeNotificationIsCorrectlyCreated() {
+        Notification likeNotification = new LikeNotification("Liker").get(context);
+        assertThat(likeNotification.extras.get(Notification.EXTRA_TITLE).toString(), is(profile.getUsername() + ", you have a new like!"));
         assertThat(likeNotification.extras.get(Notification.EXTRA_TEXT).toString(), is("Liker liked your post!"));
         assertThat(likeNotification.priority, is(Notification.PRIORITY_DEFAULT));
         assertThat(likeNotification.getSmallIcon().getResId(), is(R.drawable.logo_compact));
-        assertThat(likeNotification.getChannelId(), is(context.getString(R.string.likeNotifChannelID)));
-
-        Profile.setActiveProfile(null);
+        assertThat(likeNotification.getChannelId(), is(LikeNotification.CHANNEL_ID));
     }
 
 }

--- a/app/src/androidTest/java/ch/epfl/culturequest/social/notifications/ScanNotificationTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/social/notifications/ScanNotificationTest.java
@@ -6,34 +6,38 @@ import static org.hamcrest.Matchers.is;
 import android.app.Notification;
 import android.content.Context;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 
 import ch.epfl.culturequest.R;
 import ch.epfl.culturequest.social.Profile;
 
 
+@RunWith(AndroidJUnit4.class)
 public class ScanNotificationTest {
+    private final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    private final Profile profile = new Profile("test", "test", "Scanner", "test", "test", "test", 0, new HashMap<>());
 
-    // Tests that the like notification is correctly created
+    @Before
+    public void setup() {
+        NotificationInterface.createNotificationChannels(context);
+        Profile.setActiveProfile(profile);
+    }
+
     @Test
-    public void testScanNotification() {
-        Profile.setActiveProfile(new Profile("test", "Scanner", "test", "test", "test", "test",0,new HashMap<>()));
-        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
-
-        android.app.Notification scanNotif = new ScanNotification().get(context);
-        assertThat(scanNotif.extras.get(Notification.EXTRA_TITLE).toString(), is("Scanner, you have a new scan!"));
-        assertThat(scanNotif.extras.get(Notification.EXTRA_TEXT).toString(), is("We found a new offline scan result!"));
-        assertThat(scanNotif.priority, is(Notification.PRIORITY_DEFAULT));
-        assertThat(scanNotif.getSmallIcon().getResId(), is(R.drawable.logo_compact));
-        assertThat(scanNotif.getChannelId(), is(context.getString(R.string.scanNotifChannelID)));
-
-        Profile.setActiveProfile(null);
+    public void ScanNotificationIsCorrectlyCreated() {
+        Notification scanNotification = new ScanNotification().get(context);
+        assertThat(scanNotification.extras.get(Notification.EXTRA_TITLE).toString(), is(profile.getUsername() + ", you have a new scan!"));
+        assertThat(scanNotification.extras.get(Notification.EXTRA_TEXT).toString(), is("We found a new offline scan result!"));
+        assertThat(scanNotification.priority, is(Notification.PRIORITY_DEFAULT));
+        assertThat(scanNotification.getSmallIcon().getResId(), is(R.drawable.logo_compact));
+        assertThat(scanNotification.getChannelId(), is(ScanNotification.CHANNEL_ID));
     }
 
 }

--- a/app/src/androidTest/java/ch/epfl/culturequest/social/notifications/SightSeeingNotificationTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/social/notifications/SightSeeingNotificationTest.java
@@ -1,0 +1,41 @@
+package ch.epfl.culturequest.social.notifications;
+
+import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import android.app.Notification;
+import android.content.Context;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+
+import ch.epfl.culturequest.R;
+import ch.epfl.culturequest.social.Profile;
+
+@RunWith(AndroidJUnit4.class)
+public class SightSeeingNotificationTest {
+    private final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    private final Profile profile = new Profile("test", "test", "SightSeer", "test", "test", "test", 0, new HashMap<>());
+
+    @Before
+    public void setup() {
+        NotificationInterface.createNotificationChannels(context);
+        Profile.setActiveProfile(profile);
+    }
+
+    @Test
+    public void testSightSeeingNotification() {
+        Notification sightSeeingNotification = new SightSeeingNotification("John").get(context);
+        assertThat(sightSeeingNotification.extras.get(Notification.EXTRA_TITLE).toString(), is(profile.getUsername() + ", you have a new sightseeing event!"));
+        assertThat(sightSeeingNotification.extras.get(Notification.EXTRA_TEXT).toString(), is("John invited you to a new sightseeing event!"));
+        assertThat(sightSeeingNotification.priority, is(Notification.PRIORITY_DEFAULT));
+        assertThat(sightSeeingNotification.getSmallIcon().getResId(), is(R.drawable.logo_compact));
+        assertThat(sightSeeingNotification.getChannelId(), is(SightSeeingNotification.CHANNEL_ID));
+    }
+}

--- a/app/src/androidTest/java/ch/epfl/culturequest/social/notifications/SightseeingNotificationTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/social/notifications/SightseeingNotificationTest.java
@@ -19,7 +19,7 @@ import ch.epfl.culturequest.R;
 import ch.epfl.culturequest.social.Profile;
 
 @RunWith(AndroidJUnit4.class)
-public class SightSeeingNotificationTest {
+public class SightseeingNotificationTest {
     private final Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
     private final Profile profile = new Profile("test", "test", "SightSeer", "test", "test", "test", 0, new HashMap<>());
 
@@ -31,11 +31,11 @@ public class SightSeeingNotificationTest {
 
     @Test
     public void testSightSeeingNotification() {
-        Notification sightSeeingNotification = new SightSeeingNotification("John").get(context);
-        assertThat(sightSeeingNotification.extras.get(Notification.EXTRA_TITLE).toString(), is(profile.getUsername() + ", you have a new sightseeing event!"));
-        assertThat(sightSeeingNotification.extras.get(Notification.EXTRA_TEXT).toString(), is("John invited you to a new sightseeing event!"));
-        assertThat(sightSeeingNotification.priority, is(Notification.PRIORITY_DEFAULT));
-        assertThat(sightSeeingNotification.getSmallIcon().getResId(), is(R.drawable.logo_compact));
-        assertThat(sightSeeingNotification.getChannelId(), is(SightSeeingNotification.CHANNEL_ID));
+        Notification sightseeingNotification = new SightseeingNotification("John").get(context);
+        assertThat(sightseeingNotification.extras.get(Notification.EXTRA_TITLE).toString(), is(profile.getUsername() + ", you have a new sightseeing event!"));
+        assertThat(sightseeingNotification.extras.get(Notification.EXTRA_TEXT).toString(), is("John invited you to a new sightseeing event!"));
+        assertThat(sightseeingNotification.priority, is(Notification.PRIORITY_DEFAULT));
+        assertThat(sightseeingNotification.getSmallIcon().getResId(), is(R.drawable.logo_compact));
+        assertThat(sightseeingNotification.getChannelId(), is(SightseeingNotification.CHANNEL_ID));
     }
 }

--- a/app/src/androidTest/java/ch/epfl/culturequest/storage/LocalStorageTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/storage/LocalStorageTest.java
@@ -2,52 +2,51 @@ package ch.epfl.culturequest.storage;
 
 import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static androidx.test.espresso.matcher.ViewMatchers.assertThat;
-
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
-import android.content.ContentResolver;
-import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.net.Uri;
 import android.provider.MediaStore;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-
-import com.android21buttons.fragmenttestrule.FragmentTestRule;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.After;
-import org.junit.Rule;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
 
 import ch.epfl.culturequest.R;
-import ch.epfl.culturequest.ui.scan.ScanFragment;
 
 @RunWith(AndroidJUnit4.class)
 public class LocalStorageTest {
-    @Rule
-    // Use of ScanFragment to get access to the fragment's context for image storage tests.
-    public FragmentTestRule<?, ScanFragment> fragmentTestRule = FragmentTestRule.create(ScanFragment.class);
+    private LocalStorage localStorage;
+
+    @Before
+    public void setup() {
+        localStorage = new LocalStorage(InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver());
+        // Clear all images in shared storage before each test
+        localStorage.clearLocalStorage();
+    }
 
     @Test
     public void storeImageLocallyWithNoWifiStoresOnePendingImageInSharedStorage() {
         String selection = MediaStore.Images.Media.DISPLAY_NAME + " LIKE ?";
         String[] selectionArgs = new String[]{"pending_%"};
-        int initialPendingImageCount = countSelectedImagesInSharedStorage(selection, selectionArgs);
+        int initialPendingImageCount = localStorage.countSelectedImagesInLocalStorage(selection, selectionArgs);
 
         Bitmap bitmap = BitmapFactory.decodeResource(getApplicationContext().getResources(), R.drawable.joconde);
         try {
-            fragmentTestRule.getFragment().localStorage.storeImageLocally(bitmap, false);
+            localStorage.storeImageLocally(bitmap, false);
         } catch (Exception e) {
             fail("Test failed because of an exception: " + e.getMessage());
         }
 
-        int finalPendingImageCount = countSelectedImagesInSharedStorage(selection, selectionArgs);
+        int finalPendingImageCount = localStorage.countSelectedImagesInLocalStorage(selection, selectionArgs);
         assertThat(finalPendingImageCount, is(initialPendingImageCount + 1));
     }
 
@@ -55,23 +54,23 @@ public class LocalStorageTest {
     public void storeImageLocallyWithWifiStoresOneReadyImageInSharedStorage() {
         String selection = MediaStore.Images.Media.DISPLAY_NAME + " NOT LIKE ?";
         String[] selectionArgs = new String[]{"pending_%"};
-        int initialReadyImageCount = countSelectedImagesInSharedStorage(selection, selectionArgs);
+        int initialReadyImageCount = localStorage.countSelectedImagesInLocalStorage(selection, selectionArgs);
 
         Bitmap bitmap = BitmapFactory.decodeResource(getApplicationContext().getResources(), R.drawable.joconde);
         try {
-            fragmentTestRule.getFragment().localStorage.storeImageLocally(bitmap, true);
+            localStorage.storeImageLocally(bitmap, true);
         } catch (Exception e) {
             fail("Test failed because of an exception: " + e.getMessage());
         }
 
-        int finalReadyImageCount = countSelectedImagesInSharedStorage(selection, selectionArgs);
+        int finalReadyImageCount = localStorage.countSelectedImagesInLocalStorage(selection, selectionArgs);
         assertThat(finalReadyImageCount, is(initialReadyImageCount + 1));
     }
 
     @Test
     public void storeImageLocallyWithNullBitmapThrowsIOException() {
         IOException exception = assertThrows(IOException.class, () -> {
-            fragmentTestRule.getFragment().localStorage.storeImageLocally(null, false);
+            localStorage.storeImageLocally(null, false);
         });
         assertThat(exception.getMessage(), is("Failed to save image."));
     }
@@ -79,25 +78,10 @@ public class LocalStorageTest {
     @Test
     @After
     public void deleteAllImagesInSharedStorage() {
-        Uri collection = fragmentTestRule.getFragment().localStorage.contentUri;
-
-        ContentResolver contentResolver = getApplicationContext().getContentResolver();
-        contentResolver.delete(collection, null, null);
-        int totalImageCount = countSelectedImagesInSharedStorage(null, null);
+        localStorage.clearLocalStorage();
+        int totalImageCount = localStorage.countSelectedImagesInLocalStorage(null, null);
         assertThat(totalImageCount, is(0));
     }
 
-    private int countSelectedImagesInSharedStorage(String selection, String[] selectionArgs) {
-        Uri collection = fragmentTestRule.getFragment().localStorage.contentUri;
 
-        // Counts the number of ready images (not pending) in the shared storage
-        try (Cursor cursor = getApplicationContext().getContentResolver().query(
-                collection,
-                null,
-                selection,
-                selectionArgs,
-                null)) {
-            return cursor.getCount();
-        }
-    }
 }

--- a/app/src/androidTest/java/ch/epfl/culturequest/ui/HomeFragmentTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/ui/HomeFragmentTest.java
@@ -6,10 +6,10 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.hasChildCount;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
+import static ch.epfl.culturequest.utils.ProfileUtils.DEFAULT_PROFILE_PIC_PATH;
 
 import android.view.View;
 
@@ -46,24 +46,24 @@ public class HomeFragmentTest {
     private HomeFragment fragment;
 
 
-        public ViewAction clickChildViewWithId(final int id) {
-            return new ViewAction() {
-                @Override
-                public Matcher<View> getConstraints() {
-                    return null;
-                }
+    public ViewAction clickChildViewWithId(final int id) {
+        return new ViewAction() {
+            @Override
+            public Matcher<View> getConstraints() {
+                return null;
+            }
 
-                @Override
-                public String getDescription() {
-                    return "Click on a child view with specified id.";
-                }
+            @Override
+            public String getDescription() {
+                return "Click on a child view with specified id.";
+            }
 
-                @Override
-                public void perform(UiController uiController, View view) {
-                    View v = view.findViewById(id);
-                    v.performClick();
-                }
-            };
+            @Override
+            public void perform(UiController uiController, View view) {
+                View v = view.findViewById(id);
+                v.performClick();
+            }
+        };
 
     }
 
@@ -79,15 +79,15 @@ public class HomeFragmentTest {
         // Initialize the database with some test profiles
         ArrayList<String> myFriendsIds = new ArrayList<>();
         myFriendsIds.add("friendID");
-        Profile activeProfile = new Profile("currentUserUid", "currentUserName", "currentUserUsername", "currentUserEmail", "currentUserPhone", "currentUserProfilePicture", 400,new HashMap<>());
+        Profile activeProfile = new Profile("currentUserUid", "currentUserName", "currentUserUsername", "currentUserEmail", "currentUserPhone", "currentUserProfilePicture", 400, new HashMap<>());
         Profile.setActiveProfile(activeProfile);
         Database.setProfile(activeProfile);
-        Database.setProfile(new Profile("friendID", "testName2", "testUsername2", "testEmail2", "testPhone2", "testProfilePicture2", 300,new HashMap<>()));
+        Database.setProfile(new Profile("friendID", "testName2", "testUsername2", "testEmail2", "testPhone2", "testProfilePicture2", 300, new HashMap<>()));
         Database.addFollow("currentUserUid", "friendID");
 
         Database.uploadPost(new Post("postUid1",
                 "friendID",
-                "https://firebasestorage.googleapis.com/v0/b/culturequest.appspot.com/o/images%2F08064ffd-b463-4a99-9ee3-00446168e167?alt=media&token=9084b547-1058-4d16-8721-90adc10d867b",
+                DEFAULT_PROFILE_PIC_PATH,
                 "David of Michelangelo",
                 0,
                 0,
@@ -95,7 +95,7 @@ public class HomeFragmentTest {
 
         Database.uploadPost(new Post("postUid1",
                 "friendID",
-                "https://firebasestorage.googleapis.com/v0/b/culturequest.appspot.com/o/images%2F08064ffd-b463-4a99-9ee3-00446168e167?alt=media&token=9084b547-1058-4d16-8721-90adc10d867b",
+                DEFAULT_PROFILE_PIC_PATH,
                 "Mona Lisa",
                 1,
                 0,

--- a/app/src/androidTest/java/ch/epfl/culturequest/ui/MapsFragmentTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/ui/MapsFragmentTest.java
@@ -5,7 +5,7 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 
-import static ch.epfl.culturequest.utils.ProfileUtils.DEFAULT_PROFILE_PATH;
+import static ch.epfl.culturequest.utils.ProfileUtils.DEFAULT_PROFILE_PIC_PATH;
 
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -20,7 +20,6 @@ import org.junit.runner.RunWith;
 import java.util.HashMap;
 
 import ch.epfl.culturequest.R;
-import ch.epfl.culturequest.authentication.Authenticator;
 import ch.epfl.culturequest.database.Database;
 import ch.epfl.culturequest.social.Profile;
 import ch.epfl.culturequest.ui.map.MapsFragment;
@@ -30,7 +29,7 @@ public class MapsFragmentTest {
     @Before
     public void setUp() throws InterruptedException {
 
-        Profile profile = new Profile("test", "Johnny Doe", "Xx_john_xX", "john.doe@gmail.com", "0707070707", DEFAULT_PROFILE_PATH, 35, new HashMap<>());
+        Profile profile = new Profile("test", "Johnny Doe", "Xx_john_xX", "john.doe@gmail.com", "0707070707", DEFAULT_PROFILE_PIC_PATH, 35, new HashMap<>());
         Profile.setActiveProfile(profile);
         Database.setProfile(profile);
 

--- a/app/src/androidTest/java/ch/epfl/culturequest/ui/ProfileFragmentTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/ui/ProfileFragmentTest.java
@@ -11,7 +11,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isEnabled;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.junit.Assert.assertEquals;
-import static ch.epfl.culturequest.utils.ProfileUtils.DEFAULT_PROFILE_PATH;
+import static ch.epfl.culturequest.utils.ProfileUtils.DEFAULT_PROFILE_PIC_PATH;
 
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
@@ -64,13 +64,13 @@ public class ProfileFragmentTest {
         // Manually signs in the user before the tests
         Authenticator.manualSignIn(email, password).join();
 
-        Post post = new Post("abc", Authenticator.getCurrentUser().getUid(), DEFAULT_PROFILE_PATH
+        Post post = new Post("abc", Authenticator.getCurrentUser().getUid(), DEFAULT_PROFILE_PIC_PATH
                 , "Piece of Art", 0, 0, new ArrayList<>());
         Database.uploadPost(post);
 
-        ProfileUtils.postsAdded = 0;
+        ProfileUtils.POSTS_ADDED = 0;
 
-        profile = new Profile(Authenticator.getCurrentUser().getUid(), "Johnny Doe", "Xx_john_xX", "john.doe@gmail.com", "0707070707", DEFAULT_PROFILE_PATH, 35,new HashMap<>());
+        profile = new Profile(Authenticator.getCurrentUser().getUid(), "Johnny Doe", "Xx_john_xX", "john.doe@gmail.com", "0707070707", DEFAULT_PROFILE_PIC_PATH, 35,new HashMap<>());
         Profile.setActiveProfile(profile);
         Database.setProfile(profile);
 

--- a/app/src/main/java/ch/epfl/culturequest/ArtDescriptionDisplayActivity.java
+++ b/app/src/main/java/ch/epfl/culturequest/ArtDescriptionDisplayActivity.java
@@ -1,7 +1,7 @@
 package ch.epfl.culturequest;
 
 import static ch.epfl.culturequest.social.RarityLevel.getRarityLevel;
-import static ch.epfl.culturequest.utils.ProfileUtils.postsAdded;
+import static ch.epfl.culturequest.utils.ProfileUtils.POSTS_ADDED;
 
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
@@ -244,7 +244,7 @@ public class ArtDescriptionDisplayActivity extends AppCompatActivity {
         String uid = activeProfile.getUid();
         Database.uploadPost(new Post(postId, uid, url, artwork.getName(), new Date().getTime(), 0, new ArrayList<>())).whenComplete((lambda, e) -> {
             if (e == null) {
-                postsAdded++;
+                POSTS_ADDED++;
                 activeProfile.incrementScore(artwork.getScore());
                 activeProfile.addBadges(badges);
                 finish();

--- a/app/src/main/java/ch/epfl/culturequest/ArtDescriptionDisplayActivity.java
+++ b/app/src/main/java/ch/epfl/culturequest/ArtDescriptionDisplayActivity.java
@@ -40,7 +40,7 @@ public class ArtDescriptionDisplayActivity extends AppCompatActivity {
 
     private Bitmap scannedImage;
 
-    private static final int POPUP_DELAY = 3000;
+    private static final int POPUP_DELAY = 5000;
 
     private Button postButton;
 

--- a/app/src/main/java/ch/epfl/culturequest/ProfileCreatorActivity.java
+++ b/app/src/main/java/ch/epfl/culturequest/ProfileCreatorActivity.java
@@ -19,11 +19,9 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.google.firebase.auth.FirebaseAuth;
 import com.squareup.picasso.Picasso;
 
 import java.io.IOException;
-import java.util.Objects;
 
 import ch.epfl.culturequest.authentication.Authenticator;
 import ch.epfl.culturequest.database.Database;
@@ -112,7 +110,7 @@ public class ProfileCreatorActivity extends AppCompatActivity {
         if (!Authenticator.getCurrentUser().isAnonymous()) {
 
             //if the profile picture is not the default one, we store it in the storage
-            if (!profilePicUri.equals(ProfileUtils.DEFAULT_PROFILE_PATH))
+            if (!profilePicUri.equals(ProfileUtils.DEFAULT_PROFILE_PIC_PATH))
                 FireStorage.uploadNewProfilePictureToStorage(profile, profilePicBitmap, true).whenComplete(
                         (profile, throwable) -> {
                             if (throwable != null) {
@@ -145,7 +143,7 @@ public class ProfileCreatorActivity extends AppCompatActivity {
 
     private void setDefaultPicIfNoneSelected() {
         if (profileView.getDrawable().equals(initialDrawable)) {
-            profilePicUri = ProfileUtils.DEFAULT_PROFILE_PATH;
+            profilePicUri = ProfileUtils.DEFAULT_PROFILE_PIC_PATH;
             profile.setProfilePicture(profilePicUri);
         }
     }
@@ -166,7 +164,7 @@ public class ProfileCreatorActivity extends AppCompatActivity {
             try {
                 profilePicBitmap = MediaStore.Images.Media.getBitmap(this.getContentResolver(), profilePicture);
             } catch (IOException e) {
-                profilePicBitmap = FireStorage.getBitmapFromURL(ProfileUtils.DEFAULT_PROFILE_PATH);
+                profilePicBitmap = FireStorage.getBitmapFromURL(ProfileUtils.DEFAULT_PROFILE_PIC_PATH);
             }
         }
     }

--- a/app/src/main/java/ch/epfl/culturequest/SettingsActivity.java
+++ b/app/src/main/java/ch/epfl/culturequest/SettingsActivity.java
@@ -8,7 +8,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
-import android.media.session.PlaybackState;
 import android.net.Uri;
 import android.os.Bundle;
 import android.provider.MediaStore;
@@ -23,7 +22,6 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 
-import com.google.android.material.snackbar.Snackbar;
 import com.squareup.picasso.Picasso;
 
 import java.io.IOException;
@@ -160,7 +158,7 @@ public class SettingsActivity extends AppCompatActivity {
         try {
             profilePicBitmap = MediaStore.Images.Media.getBitmap(this.getContentResolver(), selectedImage);
         } catch (IOException e) {
-            profilePicBitmap = FireStorage.getBitmapFromURL(ProfileUtils.DEFAULT_PROFILE_PATH);
+            profilePicBitmap = FireStorage.getBitmapFromURL(ProfileUtils.DEFAULT_PROFILE_PIC_PATH);
         }
     }
 

--- a/app/src/main/java/ch/epfl/culturequest/SignUpActivity.java
+++ b/app/src/main/java/ch/epfl/culturequest/SignUpActivity.java
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import ch.epfl.culturequest.authentication.Authenticator;
 import ch.epfl.culturequest.database.Database;
 import ch.epfl.culturequest.utils.AndroidUtils;
+import ch.epfl.culturequest.social.notifications.Notification;
 
 public class SignUpActivity extends AppCompatActivity {
 
@@ -20,6 +21,9 @@ public class SignUpActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Create the notification channels on login
+        Notification.createNotificationChannels(this);
 
         // If the user is not logged in, display the sign in activity
         AndroidUtils.removeStatusBar(getWindow());

--- a/app/src/main/java/ch/epfl/culturequest/SignUpActivity.java
+++ b/app/src/main/java/ch/epfl/culturequest/SignUpActivity.java
@@ -1,15 +1,14 @@
 package ch.epfl.culturequest;
 
 import android.os.Bundle;
-import android.util.Log;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
 import ch.epfl.culturequest.authentication.Authenticator;
 import ch.epfl.culturequest.database.Database;
+import ch.epfl.culturequest.social.notifications.NotificationInterface;
 import ch.epfl.culturequest.utils.AndroidUtils;
-import ch.epfl.culturequest.social.notifications.Notification;
 
 public class SignUpActivity extends AppCompatActivity {
 
@@ -23,7 +22,7 @@ public class SignUpActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         // Create the notification channels on login
-        Notification.createNotificationChannels(this);
+        NotificationInterface.createNotificationChannels(this);
 
         // If the user is not logged in, display the sign in activity
         AndroidUtils.removeStatusBar(getWindow());

--- a/app/src/main/java/ch/epfl/culturequest/social/notifications/CompetitionNotification.java
+++ b/app/src/main/java/ch/epfl/culturequest/social/notifications/CompetitionNotification.java
@@ -4,36 +4,21 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
-import android.os.Build;
 
 import androidx.core.app.NotificationCompat;
 
 import ch.epfl.culturequest.R;
 import ch.epfl.culturequest.social.Profile;
 
-/**
- * Class that represents a notification for a new like
- */
-public class LikeNotification implements NotificationInterface {
-    private final String liker;
-
-    public static final String CHANNEL_ID = "LIKE";
-
-    /**
-     * Constructor for the LikeNotification
-     *
-     * @param liker the username of the liker
-     */
-    public LikeNotification(String liker) {
-        this.liker = liker;
-    }
+public class CompetitionNotification implements NotificationInterface {
+    public static final String CHANNEL_ID = "COMPETITION";
 
     @Override
     public Notification get(Context context) {
         return new NotificationCompat.Builder(context, CHANNEL_ID)
                 .setSmallIcon(R.drawable.logo_compact)
-                .setContentTitle(Profile.getActiveProfile().getUsername() + ", you have a new like!")
-                .setContentText(liker + " liked your post!")
+                .setContentTitle(Profile.getActiveProfile().getUsername() + ", you have a new competition!")
+                .setContentText("Click here to see your new competition!")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT).build();
     }
 
@@ -43,9 +28,9 @@ public class LikeNotification implements NotificationInterface {
      * @return the notification channel
      */
     public static NotificationChannel getNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            CharSequence name = "LikeNotification";
-            String description = "LikeNotification";
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            CharSequence name = "CompetitionNotification";
+            String description = "CompetitionNotification";
             int importance = NotificationManager.IMPORTANCE_DEFAULT;
             NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
             channel.setDescription(description);
@@ -53,4 +38,5 @@ public class LikeNotification implements NotificationInterface {
         }
         return null;
     }
+
 }

--- a/app/src/main/java/ch/epfl/culturequest/social/notifications/FollowNotification.java
+++ b/app/src/main/java/ch/epfl/culturequest/social/notifications/FollowNotification.java
@@ -1,5 +1,6 @@
 package ch.epfl.culturequest.social.notifications;
 
+import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -13,13 +14,12 @@ import ch.epfl.culturequest.social.Profile;
 /**
  * Class that represents a notification for a new follower
  */
-public final class FollowNotification implements Notification {
-
+public final class FollowNotification implements NotificationInterface {
     private final String newFollower;
-    private static final String CHANNEL_ID = "FOLLOW";
+    public static final String CHANNEL_ID = "FOLLOW";
 
     /**
-     * Constructor for the Follow Notification
+     * Constructor for the FollowNotification
      *
      * @param newFollower the username of the new follower
      */
@@ -28,10 +28,10 @@ public final class FollowNotification implements Notification {
     }
 
     @Override
-    public android.app.Notification get(Context context) {
+    public Notification get(Context context) {
         return new NotificationCompat.Builder(context, CHANNEL_ID)
                 .setSmallIcon(R.drawable.logo_compact)
-                .setContentTitle(Profile.getActiveProfile().getName() + ", you have a new follower!")
+                .setContentTitle(Profile.getActiveProfile().getUsername() + ", you have a new follower!")
                 .setContentText(newFollower + " is now following you!")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT).build();
     }

--- a/app/src/main/java/ch/epfl/culturequest/social/notifications/FollowNotification.java
+++ b/app/src/main/java/ch/epfl/culturequest/social/notifications/FollowNotification.java
@@ -1,6 +1,9 @@
 package ch.epfl.culturequest.social.notifications;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.Context;
+import android.os.Build;
 
 import androidx.core.app.NotificationCompat;
 
@@ -13,9 +16,11 @@ import ch.epfl.culturequest.social.Profile;
 public final class FollowNotification implements Notification {
 
     private final String newFollower;
+    private static final String CHANNEL_ID = "FOLLOW";
 
     /**
      * Constructor for the Follow Notification
+     *
      * @param newFollower the username of the new follower
      */
     public FollowNotification(String newFollower) {
@@ -24,10 +29,27 @@ public final class FollowNotification implements Notification {
 
     @Override
     public android.app.Notification get(Context context) {
-        return new NotificationCompat.Builder(context,  context.getString(R.string.followNotifChannelID))
+        return new NotificationCompat.Builder(context, CHANNEL_ID)
                 .setSmallIcon(R.drawable.logo_compact)
                 .setContentTitle(Profile.getActiveProfile().getName() + ", you have a new follower!")
                 .setContentText(newFollower + " is now following you!")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT).build();
+    }
+
+    /**
+     * Returns the notification channel
+     *
+     * @return the notification channel
+     */
+    public static NotificationChannel getNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = "FollowNotification";
+            String description = "FollowNotification";
+            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
+            channel.setDescription(description);
+            return channel;
+        }
+        return null;
     }
 }

--- a/app/src/main/java/ch/epfl/culturequest/social/notifications/LikeNotification.java
+++ b/app/src/main/java/ch/epfl/culturequest/social/notifications/LikeNotification.java
@@ -1,6 +1,9 @@
 package ch.epfl.culturequest.social.notifications;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.Context;
+import android.os.Build;
 
 import androidx.core.app.NotificationCompat;
 
@@ -13,6 +16,8 @@ import ch.epfl.culturequest.social.Profile;
 public class LikeNotification implements Notification {
     private final String liker;
 
+    private static final String CHANNEL_ID = "LIKE";
+
     /**
      * Constructor for the Like Notification
      * @param liker the username of the liker
@@ -23,10 +28,27 @@ public class LikeNotification implements Notification {
 
     @Override
     public android.app.Notification get(Context context) {
-        return new NotificationCompat.Builder(context, context.getString(R.string.likeNotifChannelID))
+        return new NotificationCompat.Builder(context, CHANNEL_ID)
                 .setSmallIcon(R.drawable.logo_compact)
                 .setContentTitle(Profile.getActiveProfile().getName() + ", you have a new like!")
                 .setContentText(liker + " liked your post!")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT).build();
+    }
+
+    /**
+     * Returns the notification channel
+     *
+     * @return the notification channel
+     */
+    public static NotificationChannel getNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            CharSequence name = "LikeNotification";
+            String description = "LikeNotification";
+            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
+            channel.setDescription(description);
+            return channel;
+        }
+        return null;
     }
 }

--- a/app/src/main/java/ch/epfl/culturequest/social/notifications/Notification.java
+++ b/app/src/main/java/ch/epfl/culturequest/social/notifications/Notification.java
@@ -1,11 +1,44 @@
 package ch.epfl.culturequest.social.notifications;
 
+import static androidx.core.content.ContextCompat.getSystemService;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.Context;
+import android.os.Build;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Interface that represents notifications
  */
-interface Notification {
+public interface Notification {
+
+    /**
+     * Creates the notification channels. This method can be called multiple times, it will only
+     * create the channels if they don't already exist. It should be called as soon as possible.
+     *
+     * @param context the context of the notification
+     */
+    static void createNotificationChannels(Context context) {
+        // Create the NotificationChannels, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+
+            // retrieve a list of all notifications channels
+            List<NotificationChannel> channels = new ArrayList<>();
+            channels.add(FollowNotification.getNotificationChannel());
+            channels.add(ScanNotification.getNotificationChannel());
+            channels.add(LikeNotification.getNotificationChannel());
+
+            // Register the channel with the system; you can't change the importance
+            // or other notification behaviors after this
+            NotificationManager notificationManager = getSystemService(context, NotificationManager.class);
+            Objects.requireNonNull(notificationManager).createNotificationChannels(channels);
+        }
+    }
 
     /**
      * Returns the notification ready to be sent

--- a/app/src/main/java/ch/epfl/culturequest/social/notifications/NotificationInterface.java
+++ b/app/src/main/java/ch/epfl/culturequest/social/notifications/NotificationInterface.java
@@ -34,7 +34,7 @@ public interface NotificationInterface {
             channels.add(ScanNotification.getNotificationChannel());
             channels.add(LikeNotification.getNotificationChannel());
             channels.add(CompetitionNotification.getNotificationChannel());
-            channels.add(SightSeeingNotification.getNotificationChannel());
+            channels.add(SightseeingNotification.getNotificationChannel());
 
             // Register the channel with the system; you can't change the importance
             // or other notification behaviors after this

--- a/app/src/main/java/ch/epfl/culturequest/social/notifications/NotificationInterface.java
+++ b/app/src/main/java/ch/epfl/culturequest/social/notifications/NotificationInterface.java
@@ -2,6 +2,7 @@ package ch.epfl.culturequest.social.notifications;
 
 import static androidx.core.content.ContextCompat.getSystemService;
 
+import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -14,7 +15,7 @@ import java.util.Objects;
 /**
  * Interface that represents notifications
  */
-public interface Notification {
+public interface NotificationInterface {
 
     /**
      * Creates the notification channels. This method can be called multiple times, it will only
@@ -32,6 +33,8 @@ public interface Notification {
             channels.add(FollowNotification.getNotificationChannel());
             channels.add(ScanNotification.getNotificationChannel());
             channels.add(LikeNotification.getNotificationChannel());
+            channels.add(CompetitionNotification.getNotificationChannel());
+            channels.add(SightSeeingNotification.getNotificationChannel());
 
             // Register the channel with the system; you can't change the importance
             // or other notification behaviors after this
@@ -46,5 +49,5 @@ public interface Notification {
      * @param context the context of the notification
      * @return the notification
      */
-    android.app.Notification get(Context context);
+    Notification get(Context context);
 }

--- a/app/src/main/java/ch/epfl/culturequest/social/notifications/ScanNotification.java
+++ b/app/src/main/java/ch/epfl/culturequest/social/notifications/ScanNotification.java
@@ -1,5 +1,6 @@
 package ch.epfl.culturequest.social.notifications;
 
+import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -12,15 +13,14 @@ import ch.epfl.culturequest.social.Profile;
 /**
  * Class that represents notifications for a new offline scan
  */
-public class ScanNotification implements Notification {
-
-    private static final String CHANNEL_ID = "SCAN";
+public class ScanNotification implements NotificationInterface {
+    public static final String CHANNEL_ID = "SCAN";
 
     @Override
-    public android.app.Notification get(Context context) {
+    public Notification get(Context context) {
         return new NotificationCompat.Builder(context, CHANNEL_ID)
                 .setSmallIcon(R.drawable.logo_compact)
-                .setContentTitle(Profile.getActiveProfile().getName() + ", you have a new scan!")
+                .setContentTitle(Profile.getActiveProfile().getUsername() + ", you have a new scan!")
                 .setContentText("We found a new offline scan result!")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT).build();
     }

--- a/app/src/main/java/ch/epfl/culturequest/social/notifications/ScanNotification.java
+++ b/app/src/main/java/ch/epfl/culturequest/social/notifications/ScanNotification.java
@@ -1,5 +1,7 @@
 package ch.epfl.culturequest.social.notifications;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.Context;
 
 import androidx.core.app.NotificationCompat;
@@ -12,12 +14,31 @@ import ch.epfl.culturequest.social.Profile;
  */
 public class ScanNotification implements Notification {
 
+    private static final String CHANNEL_ID = "SCAN";
+
     @Override
     public android.app.Notification get(Context context) {
-        return new NotificationCompat.Builder(context, context.getString(R.string.scanNotifChannelID))
+        return new NotificationCompat.Builder(context, CHANNEL_ID)
                 .setSmallIcon(R.drawable.logo_compact)
                 .setContentTitle(Profile.getActiveProfile().getName() + ", you have a new scan!")
                 .setContentText("We found a new offline scan result!")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT).build();
+    }
+
+    /**
+     * Returns the notification channel
+     *
+     * @return the notification channel
+     */
+    public static NotificationChannel getNotificationChannel() {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            CharSequence name = "ScanNotification";
+            String description = "ScanNotification";
+            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
+            channel.setDescription(description);
+            return channel;
+        }
+        return null;
     }
 }

--- a/app/src/main/java/ch/epfl/culturequest/social/notifications/SightSeeingNotification.java
+++ b/app/src/main/java/ch/epfl/culturequest/social/notifications/SightSeeingNotification.java
@@ -4,36 +4,31 @@ import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
-import android.os.Build;
 
 import androidx.core.app.NotificationCompat;
 
 import ch.epfl.culturequest.R;
 import ch.epfl.culturequest.social.Profile;
 
-/**
- * Class that represents a notification for a new like
- */
-public class LikeNotification implements NotificationInterface {
-    private final String liker;
-
-    public static final String CHANNEL_ID = "LIKE";
+public class SightSeeingNotification implements NotificationInterface {
+    private final String friend;
+    public static final String CHANNEL_ID = "SIGHTSEEING";
 
     /**
-     * Constructor for the LikeNotification
+     * Constructor for the SightSeeingNotification
      *
-     * @param liker the username of the liker
+     * @param friend the friend that invites to a new sightseeing
      */
-    public LikeNotification(String liker) {
-        this.liker = liker;
+    public SightSeeingNotification(String friend) {
+        this.friend = friend;
     }
 
     @Override
     public Notification get(Context context) {
         return new NotificationCompat.Builder(context, CHANNEL_ID)
                 .setSmallIcon(R.drawable.logo_compact)
-                .setContentTitle(Profile.getActiveProfile().getUsername() + ", you have a new like!")
-                .setContentText(liker + " liked your post!")
+                .setContentTitle(Profile.getActiveProfile().getUsername() + ", you have a new sightseeing event!")
+                .setContentText(friend + " invited you to a new sightseeing event!")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT).build();
     }
 
@@ -43,9 +38,9 @@ public class LikeNotification implements NotificationInterface {
      * @return the notification channel
      */
     public static NotificationChannel getNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            CharSequence name = "LikeNotification";
-            String description = "LikeNotification";
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            CharSequence name = "SightSeeingNotification";
+            String description = "SightSeeingNotification";
             int importance = NotificationManager.IMPORTANCE_DEFAULT;
             NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
             channel.setDescription(description);

--- a/app/src/main/java/ch/epfl/culturequest/social/notifications/SightseeingNotification.java
+++ b/app/src/main/java/ch/epfl/culturequest/social/notifications/SightseeingNotification.java
@@ -10,16 +10,16 @@ import androidx.core.app.NotificationCompat;
 import ch.epfl.culturequest.R;
 import ch.epfl.culturequest.social.Profile;
 
-public class SightSeeingNotification implements NotificationInterface {
+public class SightseeingNotification implements NotificationInterface {
     private final String friend;
     public static final String CHANNEL_ID = "SIGHTSEEING";
 
     /**
-     * Constructor for the SightSeeingNotification
+     * Constructor for the SightseeingNotification
      *
      * @param friend the friend that invites to a new sightseeing
      */
-    public SightSeeingNotification(String friend) {
+    public SightseeingNotification(String friend) {
         this.friend = friend;
     }
 
@@ -39,8 +39,8 @@ public class SightSeeingNotification implements NotificationInterface {
      */
     public static NotificationChannel getNotificationChannel() {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            CharSequence name = "SightSeeingNotification";
-            String description = "SightSeeingNotification";
+            CharSequence name = "SightseeingNotification";
+            String description = "SightseeingNotification";
             int importance = NotificationManager.IMPORTANCE_DEFAULT;
             NotificationChannel channel = new NotificationChannel(CHANNEL_ID, name, importance);
             channel.setDescription(description);

--- a/app/src/main/java/ch/epfl/culturequest/storage/FireStorage.java
+++ b/app/src/main/java/ch/epfl/culturequest/storage/FireStorage.java
@@ -93,12 +93,12 @@ public class FireStorage {
                         profile.setProfilePicture(taskSnapshot1.getResult().toString());
                         future.complete(profile);
                     } else {
-                        profile.setProfilePicture(ProfileUtils.DEFAULT_PROFILE_PATH);
+                        profile.setProfilePicture(ProfileUtils.DEFAULT_PROFILE_PIC_PATH);
                         future.complete(profile);
                     }
                 });
             } else {
-                profile.setProfilePicture(ProfileUtils.DEFAULT_PROFILE_PATH);
+                profile.setProfilePicture(ProfileUtils.DEFAULT_PROFILE_PIC_PATH);
                 future.complete(profile);
             }
         });

--- a/app/src/main/java/ch/epfl/culturequest/storage/LocalStorage.java
+++ b/app/src/main/java/ch/epfl/culturequest/storage/LocalStorage.java
@@ -1,9 +1,11 @@
 package ch.epfl.culturequest.storage;
 
 import static android.graphics.Bitmap.CompressFormat.JPEG;
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 
 import android.content.ContentResolver;
 import android.content.ContentValues;
+import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Build;
@@ -13,8 +15,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 public class LocalStorage {
-    public final ContentResolver resolver;
-    public final Uri contentUri;
+    private final ContentResolver resolver;
+    private final Uri contentUri;
 
     public Uri lastlyStoredImageUri;
 
@@ -84,6 +86,33 @@ public class LocalStorage {
                 throw new IOException("Failed to save image.");
             }
         }
+    }
+
+    /**
+     * Counts the number of selected images in the shared storage.
+     *
+     * @param selection     the selection clause
+     * @param selectionArgs the selection arguments
+     * @return the number of selected images in the shared storage
+     **/
+    public int countSelectedImagesInLocalStorage(String selection, String[] selectionArgs) {
+        // Counts the number of ready images (not pending) in the shared storage
+        try (Cursor cursor = getApplicationContext().getContentResolver().query(
+                contentUri,
+                null,
+                selection,
+                selectionArgs,
+                null)) {
+            return cursor.getCount();
+        }
+    }
+
+    /**
+     * Deletes all the images in the shared storage.
+     **/
+    public void clearLocalStorage() {
+        ContentResolver contentResolver = getApplicationContext().getContentResolver();
+        contentResolver.delete(contentUri, null, null);
     }
 
 }

--- a/app/src/main/java/ch/epfl/culturequest/ui/profile/ProfileFragment.java
+++ b/app/src/main/java/ch/epfl/culturequest/ui/profile/ProfileFragment.java
@@ -1,7 +1,7 @@
 package ch.epfl.culturequest.ui.profile;
 
 
-import static ch.epfl.culturequest.utils.ProfileUtils.postsAdded;
+import static ch.epfl.culturequest.utils.ProfileUtils.POSTS_ADDED;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -96,7 +96,7 @@ public class ProfileFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        int limit = postsAdded;
+        int limit = POSTS_ADDED;
         List<Post> images = this.images.getValue();
         if (limit > 0) {
             Profile.getActiveProfile().retrievePosts(limit, 0)
@@ -106,7 +106,7 @@ public class ProfileFragment extends Fragment {
                         images.sort((p1, p2) -> Long.compare(p2.getTime(), p1.getTime()));
                         pictureAdapter.notifyItemRangeInserted(0, limit);
                     });
-            postsAdded = 0;
+            POSTS_ADDED = 0;
         }
     }
 

--- a/app/src/main/java/ch/epfl/culturequest/ui/scan/ScanFragment.java
+++ b/app/src/main/java/ch/epfl/culturequest/ui/scan/ScanFragment.java
@@ -53,7 +53,7 @@ import ch.epfl.culturequest.utils.PermissionRequest;
 public class ScanFragment extends Fragment {
 
     private FragmentScanBinding binding;
-    public LocalStorage localStorage;
+    private LocalStorage localStorage;
     public static CameraSetup cameraSetup;
     public static ProcessingApi processingApi = new ProcessingApi();
     private LoadingAnimation loadingAnimation;

--- a/app/src/main/java/ch/epfl/culturequest/utils/ProfileUtils.java
+++ b/app/src/main/java/ch/epfl/culturequest/utils/ProfileUtils.java
@@ -1,17 +1,9 @@
 package ch.epfl.culturequest.utils;
 
 import android.Manifest;
-import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.os.Build;
-import android.provider.MediaStore;
-import android.view.View;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-
-import androidx.activity.result.ActivityResultLauncher;
-import androidx.activity.result.contract.ActivityResultContracts;
-import androidx.core.content.ContextCompat;
 
 import ch.epfl.culturequest.social.Profile;
 
@@ -22,8 +14,8 @@ import ch.epfl.culturequest.social.Profile;
  */
 public class ProfileUtils {
 
-    public static String DEFAULT_PROFILE_PATH = "https://firebasestorage.googleapis.com/v0/b/culturequest.appspot.com/o/profilePictures%2Fbasic_profile_picture.png?alt=media&token=8e407bd6-ad5f-401a-9b2d-7852ccfb9d62";
-    public static int postsAdded = 0;
+    public static String DEFAULT_PROFILE_PIC_PATH = "https://drive.google.com/uc?id=1gA_7AkkcoW4PJggzBvJYY2JT0dXbsr6Y";
+    public static int POSTS_ADDED = 0;
     public static String INCORRECT_USERNAME_FORMAT = "Incorrect Username Format";
     public static String USERNAME_REGEX = "^[a-zA-Z0-9_-]+$";
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,10 +9,6 @@
     <string name="title_map">Map</string>
     <string name="title_scan">Scan</string>
 
-    <string name="followNotifChannelID">FOLLOW</string>
-    <string name="likeNotifChannelID">LIKE</string>
-    <string name="scanNotifChannelID">SCAN</string>
-
     <string name="firebase">FireBase</string>
     <string name="set">SET</string>
     <string name="get">GET</string>


### PR DESCRIPTION
This PR adds all the architecture of the notifications for the competitions and sightseeings. It also improves the former work done on notifications by adding the creation of channels and by adding new tests.

In this PR all the remaining tests that were still using links from Firebase Storage were refactored to use images on Google Drive or Wikipedia instead. In fact, now the Default profile picture is hosted on the Google Drive of CultureQuest instead of Firestore Storage which will allow to save some upload and download band pass.