### PR TITLE
Fix tournament seed synchronization

### DIFF
--- a/app/src/androidTest/java/ch/epfl/culturequest/backend/tournament/SeedApiTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/backend/tournament/SeedApiTest.java
@@ -1,0 +1,168 @@
+package ch.epfl.culturequest.backend.tournament;
+
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static ch.epfl.culturequest.backend.tournament.apis.TournamentManagerApi.getTournamentSharedPrefLocation;
+import static ch.epfl.culturequest.backend.tournament.apis.TournamentManagerApi.handleTournaments;
+import static ch.epfl.culturequest.database.Database.indicateTournamentNotGenerated;
+import static ch.epfl.culturequest.database.Database.unlockTournamentGeneration;
+import static ch.epfl.culturequest.database.Database.uploadSeedToDatabase;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import ch.epfl.culturequest.backend.tournament.apis.TournamentManagerApi;
+import ch.epfl.culturequest.database.Database;
+
+public class SeedApiTest {
+
+    Context targetContext;
+
+    @Before
+    public void setUp() {
+
+        targetContext = getApplicationContext();
+
+        // clear the shared pref before starting the following tests
+        clearSharedPreferences();
+
+        // Set up the database to run on the local emulator of Firebase
+        Database.setEmulatorOn();
+
+        // clear the database before starting the following tests
+        Database.clearDatabase().join();
+    }
+
+    @After
+    public void tearDown() {
+        // clear the shared pref after the tests
+        clearSharedPreferences();
+
+        // clear the database after the tests
+        Database.clearDatabase().join();
+    }
+
+    @Test
+    public void seedCorrectlyStoredWhenGenerated(){
+
+        // Tournament has never been created and seed has never been generated in database => we generate it and upload it
+        TournamentManagerApi.handleTournaments(targetContext).join();
+
+        SharedPreferences tournamentSharedPref = getTournamentSharedPrefLocation();
+
+        // from tournamentSharedPref, get the seed seed long variable
+        Long seed = tournamentSharedPref.getLong("seed", 0);
+        assertThat(seed, is(not(0)));
+    }
+
+    @Test
+    public void seedCorrectlyStoredWhenFetched(){
+
+        Long fakeSeed = 123456789L;
+
+        // fake upload of seed to database
+        uploadSeedToDatabase(fakeSeed).join();
+
+        TournamentManagerApi.handleTournaments(targetContext).join();
+
+        SharedPreferences tournamentSharedPref = getTournamentSharedPrefLocation();
+
+        // from tournamentSharedPref, get the seed seed long variable
+        Long seed = tournamentSharedPref.getLong("seed", 0);
+        assertThat(seed, is(fakeSeed));
+    }
+
+    @Test
+    public void newSeedCorrectlyGeneratedWhenTournamentOver() {
+
+        SharedPreferences tournamentSharedPref = getTournamentSharedPrefLocation();
+
+        // fake that the tournament end date is in the past
+        Long pastDate = System.currentTimeMillis() - 1000000000; // the tournament is supposed to have started 11 days ago, so is now over
+        tournamentSharedPref.edit().putLong("tournamentDate", pastDate).commit();
+
+        // Case where nobody generated the new seed yet. So we have to generate it ourselves.
+        // => Fetched seed = the one stored in the shared pref
+
+        Long fakePreviousSeed = 123456789L;
+
+        // store a fake seed in the shared preferences
+        storeSeedInSharedPref(fakePreviousSeed);
+
+        //upload the fake seed to the database
+        uploadSeedToDatabase(fakePreviousSeed).join();
+
+        // Main method
+        handleTournaments(targetContext).join();
+
+        // Get the new seed from the shared preferences
+        Long newSeed = tournamentSharedPref.getLong("seed", 0);
+
+        // check that it's different from previous seed
+        assertThat(newSeed, is(not(fakePreviousSeed)));
+
+    }
+
+    @Test
+    public void newSeedCorrectlyFetchedWhenTournamentOver(){
+
+        SharedPreferences tournamentSharedPref = getTournamentSharedPrefLocation();
+
+        // fake that the tournament end date is in the past
+        Long pastDate = System.currentTimeMillis() - 1000000000; // the tournament is supposed to have started 11 days ago, so is now over
+        tournamentSharedPref.edit().putLong("tournamentDate", pastDate).commit();
+
+
+        // Case where someone already generated the new seed. So we just fetch it.
+
+        Long fakePreviousSeed = 123456789L;
+        Long newSeed = 987654321L;
+
+        // store a fake seed in the shared preferences
+        storeSeedInSharedPref(fakePreviousSeed);
+
+        // fake an upload of a new seed to the database by another user
+        uploadSeedToDatabase(newSeed).join();
+
+        // Main method
+        handleTournaments(targetContext).join();
+
+        // Get the new seed from the shared preferences
+        Long newStoredSeed = tournamentSharedPref.getLong("seed", 0);
+
+        // check that it's different from previous seed
+        assertThat(newStoredSeed, is(newSeed));
+
+    }
+
+    private SharedPreferences getTournamentSharedPrefLocation(){
+
+        Context context = getApplicationContext();
+
+        SharedPreferences tournamentSharedPref = context.getSharedPreferences("tournament", Context.MODE_PRIVATE);
+
+        return tournamentSharedPref;
+    }
+
+    private void clearSharedPreferences(){
+
+        SharedPreferences tournamentSharedPref = getTournamentSharedPrefLocation();
+        SharedPreferences.Editor editor = tournamentSharedPref.edit();
+        editor.clear();
+        editor.commit();
+    }
+
+    private void storeSeedInSharedPref(Long seed) {
+        SharedPreferences sharedPreferences = getTournamentSharedPrefLocation();
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putLong("seed", seed);
+        editor.apply();
+    }
+
+}

--- a/app/src/androidTest/java/ch/epfl/culturequest/backend/tournament/TournamentManagerApiTest.java
+++ b/app/src/androidTest/java/ch/epfl/culturequest/backend/tournament/TournamentManagerApiTest.java
@@ -14,6 +14,7 @@ import static ch.epfl.culturequest.database.Database.isEqualAsync;
 import static ch.epfl.culturequest.database.Database.isTournamentGenerationLocked;
 import static ch.epfl.culturequest.database.Database.lockTournamentGeneration;
 import static ch.epfl.culturequest.database.Database.unlockTournamentGeneration;
+import static ch.epfl.culturequest.database.Database.uploadSeedToDatabase;
 import static ch.epfl.culturequest.database.Database.uploadTournamentToDatabase;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -69,16 +70,14 @@ public class TournamentManagerApiTest {
     @Test
     public void tournamentCorrectlyScheduledWhenFirstTime() {
 
-        TournamentManagerApi.handleTournaments(targetContext);
+        TournamentManagerApi.handleTournaments(targetContext).join();
 
         SharedPreferences tournamentSharedPref = getTournamentSharedPrefLocation();
 
         // from tournamentSharedPref, get the tournament date tournamentDate long variable
-
         Long tournamentDate = tournamentSharedPref.getLong("tournamentDate", 0);
-
-        // check that slot isn't empty
         assertThat(tournamentDate, is(not(0)));
+
     }
 
     // Correct handling when tournament is over
@@ -102,7 +101,6 @@ public class TournamentManagerApiTest {
 
         // main function call (in the real app, this is called by onResume() handler of main activities)
         TournamentManagerApi.handleTournaments(targetContext).join();
-
 
         // check that the tournament date/schedule has been updated
         Long tournamentDate = tournamentSharedPref.getLong("tournamentDate", 0);

--- a/app/src/main/java/ch/epfl/culturequest/backend/tournament/apis/SeedApi.java
+++ b/app/src/main/java/ch/epfl/culturequest/backend/tournament/apis/SeedApi.java
@@ -1,0 +1,99 @@
+package ch.epfl.culturequest.backend.tournament.apis;
+
+import static ch.epfl.culturequest.backend.tournament.apis.TournamentManagerApi.getTournamentSharedPrefLocation;
+import static ch.epfl.culturequest.database.Database.fetchSeedIfAlreadyGenerated;
+import static ch.epfl.culturequest.database.Database.uploadSeedToDatabase;
+
+import android.content.SharedPreferences;
+
+import java.util.concurrent.CompletableFuture;
+
+public class SeedApi {
+
+    public static CompletableFuture<Void> generateOrFetchSeedThenStore(){
+
+        return generateOrFetchSeed().thenAccept(seed -> {
+            if (seed != null) {
+                storeSeedInSharedPref(seed);
+            }
+        });
+
+    }
+    private static CompletableFuture<Long> generateOrFetchSeed(){
+
+        return fetchSeedIfAlreadyGenerated().thenApply(seed -> {
+            if (seed == null) {
+                // not yet generated in database => we generate it and upload it
+                return generateAndUploadSeed();
+            }
+
+            // already generated in database
+            return seed;
+        });
+    }
+
+
+    // Generate seed, upload it to database (asynchronously), and immediately return without waiting for the upload to finish
+    private static Long generateAndUploadSeed() {
+
+        Long generatedSeed = generateSeed();
+        uploadSeedToDatabase(generatedSeed);
+        return generatedSeed;
+    }
+
+    private static Long generateSeed(){
+
+        return System.currentTimeMillis();
+    }
+    public static Long getCurrentSeed() {
+
+        // Extract the seed from the SharedPreferences once fetched or generated
+        SharedPreferences sharedPreferences = getTournamentSharedPrefLocation();
+
+        // read the Long seed from the attribute "seed" in the SharedPreferences
+        long seed = sharedPreferences.getLong("seed", 0L);
+
+        return seed;
+    }
+
+
+    // To be called when the current tournament is over => We retrieve and store the new seed
+    public static CompletableFuture<Void> handleNewSeed(Long currentSeed){
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        // check if new sew seed was generated
+        // if so, store the fetched one in shared pref
+        // otherwise, generate a new one, upload it, and store in shared pref
+
+        fetchSeedIfAlreadyGenerated().thenAccept(seed -> {
+
+            // If seed in DB != current one, another user already generated it, so no need to generate it again
+            if (seed != null && !seed.equals(currentSeed)) {
+                storeSeedInSharedPref(seed);
+                future.complete(null);
+            }
+
+            // if seed null or same as current one, nobody generated the new seed yet, so we should generate it and upload it
+            else {
+                Long newlyGeneratedSeed = generateAndUploadSeed();
+                storeSeedInSharedPref(newlyGeneratedSeed);
+                future.complete(null);
+            }
+        });
+
+        return future;
+    }
+
+    public static boolean seedAlreadyStoredInSharedPref() {
+        SharedPreferences sharedPreferences = getTournamentSharedPrefLocation();
+        return sharedPreferences.getLong("seed", -1) != -1;
+    }
+    private static void storeSeedInSharedPref(Long seed) {
+        SharedPreferences sharedPreferences = getTournamentSharedPrefLocation();
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putLong("seed", seed);
+        editor.apply();
+    }
+
+}

--- a/app/src/main/java/ch/epfl/culturequest/backend/tournament/utils/RandomApi.java
+++ b/app/src/main/java/ch/epfl/culturequest/backend/tournament/utils/RandomApi.java
@@ -1,5 +1,7 @@
 package ch.epfl.culturequest.backend.tournament.utils;
 
+import static ch.epfl.culturequest.backend.tournament.apis.SeedApi.getCurrentSeed;
+
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
@@ -9,7 +11,6 @@ import java.util.Random;
 import java.util.UUID;
 
 public class RandomApi {
-    private static final long SEED_COMPLEMENT = 517802433597L;
 
     private RandomApi() {
         // Private constructor to prevent instantiation
@@ -17,14 +18,7 @@ public class RandomApi {
 
     public static Random getRandom() { return new Random(getCurrentSeed());}
 
-    // Get fresh seed associated to the current week number and year + a complement number to add entropy
-    private static Long getCurrentSeed() {
 
-        Calendar calendar = Calendar.getInstance();
-        int weekNumber = calendar.get(Calendar.WEEK_OF_YEAR);
-        int year = calendar.get(Calendar.YEAR);
-        return (long) weekNumber + year + SEED_COMPLEMENT;
-    }
     public static String getWeeklyTournamentPseudoRandomUUID() {
 
         long seed = getCurrentSeed();
@@ -69,6 +63,5 @@ public class RandomApi {
 
         return calendar;
     }
-
 
 }

--- a/app/src/main/java/ch/epfl/culturequest/database/Database.java
+++ b/app/src/main/java/ch/epfl/culturequest/database/Database.java
@@ -1063,5 +1063,50 @@ public class Database {
         return future;
     }
 
+    public static CompletableFuture<Long> fetchSeedIfAlreadyGenerated() {
+
+        CompletableFuture<Long> seedFuture = new CompletableFuture<>();
+
+        DatabaseReference seedReference = databaseInstance.getReference().child("tournaments").child("device-synchronization").child("seed");
+
+        seedReference.addListenerForSingleValueEvent(new ValueEventListener() {
+            @Override
+            public void onDataChange(DataSnapshot dataSnapshot) {
+                Long seed = dataSnapshot.getValue(Long.class);
+                if (seed == null) {
+                    seedFuture.complete(null);
+                } else {
+                    seedFuture.complete(seed);
+                }
+            }
+
+            @Override
+            public void onCancelled(DatabaseError databaseError) {
+
+                seedFuture.completeExceptionally(new RuntimeException("Failed to read data from Firebase: " + databaseError.getMessage()));
+            }
+        });
+
+        return seedFuture;
+    }
+
+    public static CompletableFuture<Void> uploadSeedToDatabase(Long seed){
+
+        CompletableFuture<Void> voidFuture = new CompletableFuture<>();
+
+        DatabaseReference seedReference = databaseInstance.getReference().child("tournaments").child("device-synchronization").child("seed");
+        seedReference.setValue(seed, new DatabaseReference.CompletionListener() {
+            @Override
+            public void onComplete(@Nullable DatabaseError error, @NonNull DatabaseReference ref) {
+                if (error != null) {
+                    voidFuture.completeExceptionally(new RuntimeException("Failed to upload seed to database: " + error.getMessage()));
+                } else {
+                    voidFuture.complete(null);
+                }
+            }
+        });
+
+        return voidFuture;
+    }
 
 }


### PR DESCRIPTION
In the past tournament backend PR, the seed (used for pseudorandom tasks) was determined by the current week's number and year. This didn't correctly take into account that a tournament could occur across two different official weeks (delimited by the end of Sunday), so with two associated week numbers, leading to seed desynchronization between a user performing tournament-related actions (generating date, getting UID, generating or fetching it) on, say Saturday, and another on the next Monday.

This PR makes it so that seed doesn't rely on week numbers anymore, but is rather generated by the first user opening the app when it's time to schedule the tournament (either because a tournament has never been scheduled, or because the previous one is over).
Once the seed is generated, other users would fetch it, and all get synchronized this way. 

This ensures that the seed is consistent for all users across the whole time frame from when the tournament has to get scheduled, to its termination when 7 days have passed from its start.
